### PR TITLE
Add serial-based Minio uploader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gradio
 boto3
 pymongo
 python-dotenv
+pyserial

--- a/serial_minio_server.py
+++ b/serial_minio_server.py
@@ -1,0 +1,59 @@
+import json
+import os
+import serial
+import boto3
+from botocore.client import Config
+
+SERIAL_PORT = os.getenv("SERIAL_PORT", "/dev/ttyUSB0")
+BAUDRATE = int(os.getenv("SERIAL_BAUDRATE", "115200"))
+
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "localhost:9000")
+MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY")
+MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY")
+MINIO_BUCKET = os.getenv("MINIO_BUCKET", "experiments")
+USE_SSL = bool(int(os.getenv("MINIO_USE_SSL", "0")))
+
+s3_client = boto3.client(
+    "s3",
+    endpoint_url=f"{'https' if USE_SSL else 'http'}://{MINIO_ENDPOINT}",
+    aws_access_key_id=MINIO_ACCESS_KEY,
+    aws_secret_access_key=MINIO_SECRET_KEY,
+    config=Config(signature_version="s3v4"),
+)
+
+
+def listen_and_upload():
+    """Listen on serial port for JSON messages and upload to Minio."""
+    os.makedirs("/tmp/serial_uploads", exist_ok=True)
+    with serial.Serial(SERIAL_PORT, BAUDRATE, timeout=10) as ser:
+        while True:
+            line = ser.readline()
+            if not line:
+                continue
+            try:
+                data = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                print("Received invalid JSON")
+                continue
+
+            # Prepare object key
+            name = data.get("name", "unknown")
+            exp_date = data.get("date", "unknown_date")
+            experiment = data.get("experiment", "experiment")
+            key = f"{exp_date}/{experiment}_{name}.json"
+
+            # Write data to a temporary file
+            tmp_path = os.path.join("/tmp/serial_uploads", os.path.basename(key))
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+
+            # Upload to Minio
+            try:
+                s3_client.upload_file(tmp_path, MINIO_BUCKET, key)
+                print(f"Uploaded {key} to bucket {MINIO_BUCKET}")
+            except Exception as e:
+                print(f"Failed to upload {key}: {e}")
+
+
+if __name__ == "__main__":
+    listen_and_upload()

--- a/uploader_ui.py
+++ b/uploader_ui.py
@@ -1,0 +1,61 @@
+import json
+import os
+import serial
+import gradio as gr
+from datetime import date
+
+SERIAL_PORT = os.getenv("SERIAL_PORT", "/dev/ttyUSB0")
+BAUDRATE = int(os.getenv("SERIAL_BAUDRATE", "115200"))
+
+
+def send_to_serial(data: dict) -> str:
+    """Send JSON data over a serial connection."""
+    try:
+        with serial.Serial(SERIAL_PORT, BAUDRATE, timeout=10) as ser:
+            message = json.dumps(data)
+            # Add newline as delimiter
+            ser.write(message.encode("utf-8") + b"\n")
+        return "Data sent successfully"
+    except Exception as e:
+        return f"Failed to send data: {e}"
+
+
+def upload(name: str, orcid: str, exp_date: str, experiment: str, json_file) -> str:
+    try:
+        file_content = json_file.decode("utf-8")
+        json_data = json.loads(file_content)
+    except Exception as e:
+        return f"Invalid JSON file: {e}"
+
+    payload = {
+        "name": name,
+        "orcid": orcid,
+        "date": exp_date,
+        "experiment": experiment,
+        "data": json_data,
+    }
+    return send_to_serial(payload)
+
+
+def default_date() -> str:
+    return date.today().isoformat()
+
+
+with gr.Blocks() as demo:
+    gr.Markdown("## Experiment Uploader")
+    name = gr.Textbox(label="Name")
+    orcid = gr.Textbox(label="ORCID")
+    exp_date = gr.Textbox(label="Date", value=default_date())
+    experiment = gr.Textbox(label="Experiment Name")
+    json_file = gr.File(label="JSON Data File", file_count="single")
+    submit = gr.Button("Upload")
+    output = gr.Textbox(label="Status")
+
+    submit.click(
+        upload,
+        inputs=[name, orcid, exp_date, experiment, json_file],
+        outputs=output,
+    )
+
+if __name__ == "__main__":
+    demo.launch()


### PR DESCRIPTION
## Summary
- add Gradio UI for collecting experiment data and sending it over serial
- add server script that listens on serial and uploads to Minio
- include `pyserial` in requirements

## Testing
- `python -m py_compile greet.py uploader_ui.py serial_minio_server.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6841e85e82fc8325801d66e76d26cc69